### PR TITLE
iss11: Remove the 'book of the month'

### DIFF
--- a/home/static/home/css/home.css
+++ b/home/static/home/css/home.css
@@ -57,7 +57,7 @@
     .grid-container{
         border: solid;
         display: grid;
-        grid-template-rows: 20% 65% 15%;
+        grid-template-rows: 35% 65%;
         height: 97vh;
     }
 

--- a/home/templates/home/home.html
+++ b/home/templates/home/home.html
@@ -52,12 +52,5 @@
             </div>
         </div>
     </div>
-
-    <div class="font-18 quote">
-        Favorite Book of the Month:&nbsp
-        <span>
-            'The Way of Kings' written by Brandon Sanderson
-        </span>
-    </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
closes: #16 

Task Outcome: Removed the book of the month from the landing page. Also changed the grid to allow the greeting to take up 35% of the page and the menu to take up 35%.